### PR TITLE
Fix round function for very large or small nums

### DIFF
--- a/optim.js
+++ b/optim.js
@@ -46,5 +46,6 @@ module.exports = function compress(input, maxPrecision = 2) {
 };
 
 function round(value = 0, decimals = 0) {
-  return Number(Math.round(`${value}e${decimals}`) + `e-${decimals}`);
+  multiplier=Math.pow(10, decimals)
+  return Math.round(value*multiplier)/multiplier
 }


### PR DESCRIPTION
If value is something like "1.13686838e-13", then this function was returning NaN rather than 0